### PR TITLE
required to recognize go reports

### DIFF
--- a/go_test.sh
+++ b/go_test.sh
@@ -2,6 +2,7 @@
 
 PACKAGES=$(find ./ -type d -not -path '*/\.*' -not -path "*/\webapp*")
 echo $PACKAGES
+echo 'mode: count' > coverage.txt
 for pkg in $PACKAGES;do
 if go test -coverprofile=coverage-one.out -covermode=atomic $pkg; then
 cat coverage-one.out >> coverage.txt


### PR DESCRIPTION
I'll look into ways of not requiring this, but for now 👍 
